### PR TITLE
Prefetch streams and subtitles on details screen open

### DIFF
--- a/app/src/main/java/com/lumera/app/ui/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/lumera/app/ui/details/DetailsViewModel.kt
@@ -58,6 +58,12 @@ class DetailsViewModel @Inject constructor(
     private var loadRequestVersion: Long = 0L
     private var loadedContentKey: String? = null
 
+    // Prefetched streams cache
+    private var prefetchStreamsJob: Job? = null
+    private var prefetchedStreamKey: String? = null
+    private var prefetchedStreams: List<Stream>? = null
+    private var prefetchedSubtitles: List<AddonSubtitle>? = null
+
     // Stash for undo: holds deleted history entries until the user leaves the screen
     private var clearedHistoryStash: List<WatchHistoryEntity> = emptyList()
     private var clearedResumeId: String? = null
@@ -115,6 +121,10 @@ class DetailsViewModel @Inject constructor(
                     addonSubtitles = emptyList(),
                     availableStreams = emptyList()
                 )
+
+                // Start fetching streams in the background so they're ready when the user hits Play
+                val prefetchId = resumePlaybackId ?: streamFetchId
+                prefetchStreams(details.type, prefetchId)
             } catch (ce: CancellationException) {
                 throw ce
             } catch (e: Exception) {
@@ -170,6 +180,24 @@ class DetailsViewModel @Inject constructor(
         )
     }
 
+    private fun prefetchStreams(type: String, id: String) {
+        prefetchStreamsJob?.cancel()
+        val key = "$type:$id"
+        prefetchedStreamKey = key
+        prefetchedStreams = null
+        prefetchedSubtitles = null
+        prefetchStreamsJob = viewModelScope.launch {
+            try {
+                val streamsDeferred = async { repository.getStreams(type, id) }
+                val subtitlesDeferred = async { subtitleRepository.getSubtitles(type, id) }
+                prefetchedStreams = streamsDeferred.await()
+                prefetchedSubtitles = subtitlesDeferred.await()
+            } catch (_: Exception) {
+                // Prefetch failed silently — loadStreams will fetch fresh
+            }
+        }
+    }
+
     // 2. Open Sources (Movie OR Specific Episode)
     fun loadStreams(
         type: String,
@@ -198,11 +226,29 @@ class DetailsViewModel @Inject constructor(
             )
 
             try {
-                val streamsDeferred = async { repository.getStreams(type, id) }
-                val subtitlesDeferred = async { subtitleRepository.getSubtitles(type, id) }
+                // Use prefetched results if available, otherwise fetch fresh
+                val rawStreams: List<Stream>
+                val addonSubtitles: List<AddonSubtitle>
+                val prefetchKey = "$type:$id"
 
-                val rawStreams = streamsDeferred.await()
-                val addonSubtitles = subtitlesDeferred.await()
+                if (prefetchedStreamKey == prefetchKey) {
+                    prefetchStreamsJob?.join()
+                    if (prefetchedStreams != null) {
+                        rawStreams = prefetchedStreams!!
+                        addonSubtitles = prefetchedSubtitles ?: emptyList()
+                    } else {
+                        // Prefetch failed — fetch fresh
+                        val streamsDeferred = async { repository.getStreams(type, id) }
+                        val subtitlesDeferred = async { subtitleRepository.getSubtitles(type, id) }
+                        rawStreams = streamsDeferred.await()
+                        addonSubtitles = subtitlesDeferred.await()
+                    }
+                } else {
+                    val streamsDeferred = async { repository.getStreams(type, id) }
+                    val subtitlesDeferred = async { subtitleRepository.getSubtitles(type, id) }
+                    rawStreams = streamsDeferred.await()
+                    addonSubtitles = subtitlesDeferred.await()
+                }
 
                 // Read sorting preferences from the active profile
                 val activeProfileId = profileConfigurationManager.getLastActiveProfileId()

--- a/app/src/main/java/com/lumera/app/ui/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/lumera/app/ui/details/DetailsViewModel.kt
@@ -13,6 +13,7 @@ import com.lumera.app.data.repository.AddonRepository
 import com.lumera.app.data.repository.SubtitleRepository
 import com.lumera.app.data.stream.StreamSortingService
 import com.lumera.app.domain.AddonSubtitle
+import com.lumera.app.domain.episodeStreamId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import com.lumera.app.data.model.WatchHistoryEntity
 import kotlinx.coroutines.flow.firstOrNull
@@ -123,7 +124,17 @@ class DetailsViewModel @Inject constructor(
                 )
 
                 // Start fetching streams in the background so they're ready when the user hits Play
-                val prefetchId = resumePlaybackId ?: streamFetchId
+                val prefetchId = if (resumePlaybackId != null) {
+                    resumePlaybackId
+                } else if (details.type == "series") {
+                    // Prefetch the first episode — matches what the Play button will request
+                    val firstEpisode = details.videos
+                        ?.filter { it.season > 0 && it.episode > 0 }
+                        ?.minWithOrNull(compareBy<com.lumera.app.data.model.stremio.MetaVideo> { it.season }.thenBy { it.episode })
+                    firstEpisode?.let { episodeStreamId(streamFetchId, it) } ?: streamFetchId
+                } else {
+                    streamFetchId
+                }
                 prefetchStreams(details.type, prefetchId)
             } catch (ce: CancellationException) {
                 throw ce


### PR DESCRIPTION
## Summary

- Starts fetching streams and subtitles in the background as soon as the details screen loads, before the user taps Play
- When Play is pressed, prefetched results are used immediately if ready, or the in-flight request is awaited — no duplicate network calls
- Falls back gracefully to a fresh fetch if the prefetch failed or the requested ID doesn't match the cache
- For series with watch history, prefetches the resume episode's streams; otherwise prefetches the main item

## How it works

1. `loadDetails()` calls `prefetchStreams(type, id)` after meta resolves
2. `prefetchStreams()` launches a background coroutine that fetches streams + subtitles concurrently and caches them in-memory
3. `loadStreams()` (triggered by Play) checks the cache key — if it matches, it `join()`s the prefetch job (instant if already done) and uses the cached results

## Test plan

- [ ] Open a movie's details screen → tap Play → sources should appear faster than before
- [ ] Open details, wait a few seconds, tap Play → sources should appear instantly (prefetch completed)
- [ ] Open details, tap Play immediately → should wait for prefetch to finish, then show sources (no duplicate requests)
- [ ] Open a series with watch history → Play should prefetch the correct resume episode
- [ ] Navigate away and back to the same item → no redundant prefetch (existing cache reused)
- [ ] If addons are slow/down, Play should still work (falls back to fresh fetch)